### PR TITLE
Ensure domain dir exists

### DIFF
--- a/src/DeployRunner.php
+++ b/src/DeployRunner.php
@@ -196,7 +196,9 @@ class DeployRunner
         $host->roles($server->getRoles());
         $host->set('domain', $stage->getDomain());
         $host->set('deploy_path', function () {
-            return run('mkdir -p ~/apps/{{domain}}/shared');
+            // Ensure directory exists before returning it
+            run('mkdir -p ~/apps/{{domain}}/shared');
+            return run('realpath ~/apps/{{domain}}');
         });
         $host->set('configuration_stage', $stage);
 


### PR DESCRIPTION
On a new environment, the domain directory doesn't exist. There's no limit for us to just create the directory, which prevents some extra manual steps for the user.

Error that's prevented this way:
```
In Client.php line 103:

  The command "realpath ~/apps/hntestizabella.hypernode.io" failed.

  Exit Code: 1 (General error)

  Host Name: production:hntestizabella.hypernode.io

  ================
  realpath: /data/web/apps/hntestizabella.hypernode.io: No such file or dire
  ctory
```