### PR TITLE
Remove sentry

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -40,11 +40,6 @@ class Application
      */
     public function run(): int
     {
-        sentryInit([
-            'dsn' => 'https://85e2b396851b4fcc9cc5df626b974687@sentry.hipex.cloud/10',
-            'release' => $this->getVersion()
-        ]);
-
         $container = $this->createDiContainer();
         $application = new ConsoleApplication();
         $application->setName(


### PR DESCRIPTION
Sentry is timing out, making every command wait for 30 seconds.

With sentry:
```
$ time hypernode-deploy build

...

hypernode-deploy build  0.12s user 0.03s system 0% cpu 28.204 total
```

Without sentry:
```
$ time hypernode-deploy build

...

hypernode-deploy build  0.05s user 0.01s system 100% cpu 0.060 total
```