### PR TITLE
DeployRunner: return deployer exit code for runStage

### DIFF
--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -33,7 +33,6 @@ class Build extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->deployRunner->run($output, 'build', 'build');
-        return 0;
+        return $this->deployRunner->run($output, 'build', 'build');
     }
 }

--- a/src/Command/ComposerAuth.php
+++ b/src/Command/ComposerAuth.php
@@ -34,7 +34,6 @@ class ComposerAuth extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->deployRunner->run($output, 'build', 'deploy:vendors:auth');
-        return 0;
+        return $this->deployRunner->run($output, 'build', 'deploy:vendors:auth');
     }
 }

--- a/src/Command/Deploy.php
+++ b/src/Command/Deploy.php
@@ -35,7 +35,6 @@ class Deploy extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->deployRunner->run($output, $input->getArgument('stage'), 'deploy');
-        return 0;
+        return $this->deployRunner->run($output, $input->getArgument('stage'), 'deploy');
     }
 }

--- a/src/Command/RunTask.php
+++ b/src/Command/RunTask.php
@@ -36,7 +36,6 @@ class RunTask extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->deployRunner->run($output, $input->getArgument('stage'), $input->getArgument('task'));
-        return 0;
+        return $this->deployRunner->run($output, $input->getArgument('stage'), $input->getArgument('task'));
     }
 }

--- a/src/DeployRunner.php
+++ b/src/DeployRunner.php
@@ -5,6 +5,7 @@ namespace Hypernode\Deploy;
 use Deployer\Deployer;
 use Deployer\Exception\Exception;
 use Deployer\Exception\GracefulShutdownException;
+use Deployer\Host\Host;
 use Hypernode\Deploy\Console\Output\OutputWatcher;
 use Hypernode\Deploy\Deployer\RecipeLoader;
 use Hypernode\Deploy\Exception\InvalidConfigurationException;
@@ -67,10 +68,8 @@ class DeployRunner
      * @throws GracefulShutdownException
      * @throws Throwable
      * @throws Exception
-     *
-     * @return void
      */
-    public function run(OutputInterface $output, string $stage, string $task = 'deploy')
+    public function run(OutputInterface $output, string $stage, string $task = 'deploy'): int
     {
         $console = new Application();
         $deployer = new Deployer($console);
@@ -87,9 +86,10 @@ class DeployRunner
             $this->initializeDeployer($deployer);
         } catch (InvalidConfigurationException $e) {
             $output->write($e->getMessage());
-            return;
+            return 1;
         }
-        $this->runStage($deployer, $stage, $task);
+
+        return $this->runStage($deployer, $stage, $task);
     }
 
     /**
@@ -273,7 +273,7 @@ class DeployRunner
      * @throws Throwable
      * @throws Exception
      */
-    private function runStage(Deployer $deployer, string $stage, string $task = 'deploy'): void
+    private function runStage(Deployer $deployer, string $stage, string $task = 'deploy'): int
     {
         $hosts = $deployer->selector->select("stage=$stage");
         if (empty($hosts)) {
@@ -283,30 +283,30 @@ class DeployRunner
         $tasks = $deployer->scriptManager->getTasks($task);
         $executor = $deployer->master;
 
-        try {
-            /**
-             * Set the env variable to tell deployer to deploy the hosts sequentially instead of parallel.
-             * @see \Deployer\Executor\Master::runTask()
-             */
-            putenv('DEPLOYER_LOCAL_WORKER=true');
-            $executor->run($tasks, $hosts);
-        } catch (Throwable $exception) {
-            $deployer->output->writeln('[' . \get_class($exception) . '] ' . $exception->getMessage());
-            $deployer->output->writeln($exception->getTraceAsString());
+        /**
+         * Set the env variable to tell deployer to deploy the hosts sequentially instead of parallel.
+         * @see \Deployer\Executor\Master::runTask()
+         */
+        putenv('DEPLOYER_LOCAL_WORKER=true');
+        $exitCode = $executor->run($tasks, $hosts);
 
-            if ($exception instanceof GracefulShutdownException) {
-                throw $exception;
-            }
-
-            // Check if we have tasks to execute on failure
-            if ($deployer['fail']->has($task)) {
-                $taskName = $deployer['fail']->get($task);
-                $tasks = $deployer->scriptManager->getTasks($taskName);
-
-                $executor->run($tasks, $hosts);
-            }
-            throw $exception;
+        if ($exitCode === 0) {
+            return 0;
         }
+
+        if ($exitCode === GracefulShutdownException::EXIT_CODE) {
+            return 1;
+        }
+
+        // Check if we have tasks to execute on failure
+        if ($deployer['fail']->has($task)) {
+            $taskName = $deployer['fail']->get($task);
+            $tasks = $deployer->scriptManager->getTasks($taskName);
+
+            $executor->run($tasks, $hosts);
+        }
+
+        return $exitCode;
     }
 
     private function tryGetConfiguration(): Configuration


### PR DESCRIPTION
When Deployer tasks were failing, `hypernode-deploy` did not return a non-zero exit code.