### PR TITLE
console: Add customized ConsoleLogger with different verbosity map

### DIFF
--- a/src/Console/Output/ConsoleLogger.php
+++ b/src/Console/Output/ConsoleLogger.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file was originally part of the Symfony Console package and has been modified to change the verbosity level map.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Hypernode\Deploy\Console\Output;
+
+use Psr\Log\AbstractLogger;
+use Psr\Log\InvalidArgumentException;
+use Psr\Log\LogLevel;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * PSR-3 compliant console logger.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @see https://www.php-fig.org/psr/psr-3/
+ */
+class ConsoleLogger extends AbstractLogger
+{
+    public const INFO = 'info';
+    public const ERROR = 'error';
+
+    private OutputInterface $output;
+    private array $verbosityLevelMap = [
+        LogLevel::EMERGENCY => OutputInterface::VERBOSITY_NORMAL,
+        LogLevel::ALERT => OutputInterface::VERBOSITY_NORMAL,
+        LogLevel::CRITICAL => OutputInterface::VERBOSITY_NORMAL,
+        LogLevel::ERROR => OutputInterface::VERBOSITY_NORMAL,
+        LogLevel::WARNING => OutputInterface::VERBOSITY_NORMAL,
+        LogLevel::NOTICE => OutputInterface::VERBOSITY_NORMAL,
+        LogLevel::INFO => OutputInterface::VERBOSITY_NORMAL,
+        LogLevel::DEBUG => OutputInterface::VERBOSITY_VERBOSE,
+    ];
+    private array $formatLevelMap = [
+        LogLevel::EMERGENCY => self::ERROR,
+        LogLevel::ALERT => self::ERROR,
+        LogLevel::CRITICAL => self::ERROR,
+        LogLevel::ERROR => self::ERROR,
+        LogLevel::WARNING => self::INFO,
+        LogLevel::NOTICE => self::INFO,
+        LogLevel::INFO => self::INFO,
+        LogLevel::DEBUG => self::INFO,
+    ];
+    private bool $errored = false;
+
+    public function __construct(OutputInterface $output, array $verbosityLevelMap = [], array $formatLevelMap = [])
+    {
+        $this->output = $output;
+        $this->verbosityLevelMap = $verbosityLevelMap + $this->verbosityLevelMap;
+        $this->formatLevelMap = $formatLevelMap + $this->formatLevelMap;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return void
+     */
+    public function log($level, $message, array $context = [])
+    {
+        if (!isset($this->verbosityLevelMap[$level])) {
+            throw new InvalidArgumentException(sprintf('The log level "%s" does not exist.', $level));
+        }
+
+        $output = $this->output;
+
+        // Write to the error output if necessary and available
+        if (self::ERROR === $this->formatLevelMap[$level]) {
+            if ($this->output instanceof ConsoleOutputInterface) {
+                $output = $this->output->getErrorOutput();
+            }
+            $this->errored = true;
+        }
+
+        // the if condition check isn't necessary -- it's the same one that $output will do internally anyway.
+        // We only do it for efficiency here as the message formatting is relatively expensive.
+        if ($output->getVerbosity() >= $this->verbosityLevelMap[$level]) {
+            $output->writeln(
+                sprintf(
+                    '<%1$s>[%2$s] %3$s</%1$s>',
+                    $this->formatLevelMap[$level],
+                    $level,
+                    $this->interpolate($message, $context)
+                ),
+                $this->verbosityLevelMap[$level]
+            );
+        }
+    }
+
+    /**
+     * Returns true when any messages have been logged at error levels.
+     *
+     * @return bool
+     */
+    public function hasErrored()
+    {
+        return $this->errored;
+    }
+
+    /**
+     * Interpolates context values into the message placeholders.
+     *
+     * @author PHP Framework Interoperability Group
+     */
+    private function interpolate(string $message, array $context): string
+    {
+        if (!str_contains($message, '{')) {
+            return $message;
+        }
+
+        $replacements = [];
+        foreach ($context as $key => $val) {
+            if (null === $val || \is_scalar($val) || (\is_object($val) && method_exists($val, '__toString'))) {
+                $replacements["{{$key}}"] = $val;
+            } elseif ($val instanceof \DateTimeInterface) {
+                $replacements["{{$key}}"] = $val->format(\DateTime::RFC3339);
+            } elseif (\is_object($val)) {
+                $replacements["{{$key}}"] = '[object ' . \get_class($val) . ']';
+            } else {
+                $replacements["{{$key}}"] = '[' . \gettype($val) . ']';
+            }
+        }
+
+        return strtr($message, $replacements);
+    }
+}

--- a/src/Di/ConsoleDefinition.php
+++ b/src/Di/ConsoleDefinition.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Hypernode\Deploy\Di;
 
+use Hypernode\Deploy\Console\Output\ConsoleLogger;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 


### PR DESCRIPTION
For a console application, all logging with log level higher than debug should be written to console by default.

We were making use of Symfony Console's ConsoleLogger component which has its own defaults, now we have our own (derived) version of the `ConsoleLogger`.