### PR TITLE
stage/deploy: Fix running `deploy:release` twice

### DIFF
--- a/src/Deployer/Task/Deploy/PrepareTask.php
+++ b/src/Deployer/Task/Deploy/PrepareTask.php
@@ -23,9 +23,5 @@ class PrepareTask extends TaskBase
             'deploy:shared',
             'deploy:writable',
         ]);
-        task('deploy:prepare_release', [
-            'deploy:prepare',
-            'deploy:release',
-        ])->select("roles=$role");
     }
 }

--- a/src/Deployer/Task/Deploy/UploadTask.php
+++ b/src/Deployer/Task/Deploy/UploadTask.php
@@ -30,7 +30,7 @@ class UploadTask extends TaskBase
         task('deploy:upload', [
             'deploy:info',
             'prepare:ssh',
-            'deploy:prepare_release',
+            'deploy:release',
             'deploy:copy',
             'deploy:deploy',
         ])->select("roles=$role");


### PR DESCRIPTION
This caused the `deploy:cleanup` task to remove the just deployed release