### PR TITLE
Don't try public symlink if it already exists

### DIFF
--- a/src/Deployer/Task/Deploy/LinkTask.php
+++ b/src/Deployer/Task/Deploy/LinkTask.php
@@ -29,9 +29,9 @@ class LinkTask extends TaskBase
                 } else {
                     run('rmdir /data/web/public');
                 }
+            } else {
+                run('ln -s {{current_path}}/{{public_folder}} /data/web/public');
             }
-
-            run('ln -s {{current_path}}/{{public_folder}} /data/web/public');
         })->select("roles=$role");
     }
 }

--- a/src/Deployer/Task/Deploy/LinkTask.php
+++ b/src/Deployer/Task/Deploy/LinkTask.php
@@ -28,6 +28,7 @@ class LinkTask extends TaskBase
                     return;
                 } else {
                     run('rmdir /data/web/public');
+                    run('ln -s {{current_path}}/{{public_folder}} /data/web/public');
                 }
             } else {
                 run('ln -s {{current_path}}/{{public_folder}} /data/web/public');


### PR DESCRIPTION
If there's already a lingering public symlink, don't try to redo the symlink. Only do so if it doesn't exist yet