### PR TITLE
Ensure .hypernode exists

### DIFF
--- a/src/Deployer/Task/PlatformConfiguration/NginxSyncTask.php
+++ b/src/Deployer/Task/PlatformConfiguration/NginxSyncTask.php
@@ -59,6 +59,7 @@ class NginxSyncTask extends TaskBase implements ConfigurableTaskInterface
                 '--delete',
             ];
             $args = implode(' ', array_map('escapeshellarg', $args));
+            run("mkdir -p {{nginx_release_path}}");
             run("rsync {$args} {{nginx/config_path}}/ {{nginx_release_path}}/");
             run("ln -sf {{nginx_current_path}} /data/web/nginx/{{domain}}");
         });

--- a/src/Deployer/Task/PlatformConfiguration/SupervisorUploadTask.php
+++ b/src/Deployer/Task/PlatformConfiguration/SupervisorUploadTask.php
@@ -55,6 +55,7 @@ class SupervisorUploadTask extends TaskBase implements ConfigurableTaskInterface
                 ];
                 upload($sourceDir . '/', '{{supervisor/config_path}}/');
                 $args = implode(' ', array_map('escapeshellarg', $args));
+                run("mkdir -p {{supervisor_release_path}}");
                 run("rsync {$args} {{supervisor/config_path}}/ {{supervisor_release_path}}/");
             }
         );


### PR DESCRIPTION
Fixes issues where Nginx tries to rsync to the `.hypernode/nginx` dir