### PR TITLE
Backport #24: ci: Fix non-templated tag spec in release_semantic_versions.sh

### DIFF
--- a/ci/release_semantic_versions.sh
+++ b/ci/release_semantic_versions.sh
@@ -2,7 +2,7 @@
 
 IMAGE=${IMAGE:-quay.io/hypernode/deploy}
 INPUT_VERSION=${INPUT_VERSION:-}
-TAG_SPECS="php8.1-node18"
+TAG_SPECS="php${PHP_VERSION}-node${NODE_VERSION}"
 
 if [ ! -n "${INPUT_VERSION}" ]; then
     echo "No input version provided, stopping".


### PR DESCRIPTION
Backport to v1 of PR #24 