### PR TITLE
Forwardport: Install python3 as default python executable

### DIFF
--- a/ci/build/Dockerfile
+++ b/ci/build/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update && \
         bash \
         jq \
         ca-certificates \
+        python3 \
         wget \
         curl \
         openssl \
@@ -103,6 +104,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- --1 --filename=composer1
 RUN curl -sS https://getcomposer.org/installer | php -- --2.2 --filename=composer2 && mv composer2 /usr/local/bin/ && chmod +x /usr/local/bin/composer2
 # Use version 1 for main composer binary
 RUN rm -f /usr/local/bin/composer; ln -s /usr/local/bin/composer2 /usr/local/bin/composer
+
+# Set python3 as default python executable
+RUN ln -s /usr/bin/python3 /usr/local/bin/python
 
 # Copy container files
 COPY ./ci/build/files /


### PR DESCRIPTION
This is a forwardport of #72.

Some build systems require Python to be available. As most of the industry has moved on to Python 3, let's install just that and use that version as the default python executable.