### PR TITLE
increase brancher node wait timeout

### DIFF
--- a/src/Brancher/BrancherHypernodeManager.php
+++ b/src/Brancher/BrancherHypernodeManager.php
@@ -81,7 +81,7 @@ class BrancherHypernodeManager
      * @throws HypernodeApiServerException
      * @throws TimeoutException
      */
-    public function waitForAvailability(string $brancherHypernode, int $timeout = 900): void
+    public function waitForAvailability(string $brancherHypernode, int $timeout = 1500): void
     {
         $latest = microtime(true);
         $timeElapsed = 0;


### PR DESCRIPTION
in the event where there is not enough compute capacity available the system will start creating new cloud resources on the fly. in that case we should not give up too quickly but wait a bit longer.

to address:
```
Run hypernode-deploy deploy acceptance -vvv
[info] Creating an brancher Hypernode based on mytesthypernodename.
[info] Successfully requested brancher Hypernode, name is mytesthypernodename-ephmabci8.
[info] Waiting for brancher Hypernode to become available...
Got an expected exception during the allowed error window of HTTP code 404, waiting for mytesthypernodename-ephmabci8 to become available[info] Stopping brancher Hypernode mytesthypernodename-ephmabci8...

In BrancherHypernodeManager.php line 132:
                                                                               
  [Hypernode\Deploy\Exception\TimeoutException]                                
  Timed out waiting for brancher Hypernode mytesthypernodename-ephmabci8 to become  
   available
```