### PR TITLE
ci/image: Install virtualenv

### DIFF
--- a/ci/build/Dockerfile
+++ b/ci/build/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update && \
         jq \
         ca-certificates \
         python3 \
+        virtualenv \
         wget \
         curl \
         openssl \


### PR DESCRIPTION
We use this very often when deploying python applications with Hypernode Deploy