### PR TITLE
Remove roles selector from builtin tasks

### DIFF
--- a/src/DeployRunner.php
+++ b/src/DeployRunner.php
@@ -14,8 +14,6 @@ use Hypernode\Deploy\Exception\CreateBrancherHypernodeFailedException;
 use Hypernode\Deploy\Exception\InvalidConfigurationException;
 use Hypernode\Deploy\Exception\TimeoutException;
 use Hypernode\Deploy\Exception\ValidationException;
-use Hypernode\DeployConfiguration\Configurable\ServerRoleConfigurableInterface;
-use Hypernode\DeployConfiguration\Configurable\StageConfigurableInterface;
 use Hypernode\DeployConfiguration\Configuration;
 use Hypernode\DeployConfiguration\Server;
 use Hypernode\DeployConfiguration\Stage;
@@ -135,7 +133,7 @@ class DeployRunner
     }
 
     /**
-     * Configure deploy tasks based on specific configuration in Hipex deploy configuration
+     * Configure deploy tasks based on specific configuration in Hypernode Deploy configuration
      * @throws InvalidConfigurationException
      */
     private function initializeConfigurableTask(ConfigurableTaskInterface $task, Configuration $mainConfig): void
@@ -146,20 +144,8 @@ class DeployRunner
         );
 
         foreach ($configurations as $taskConfig) {
-            if (!$task->supports($taskConfig)) {
-                continue;
-            }
-
-            $deployerTask = $task->configureWithTaskConfig($taskConfig);
-            if ($deployerTask) {
-                if ($taskConfig instanceof StageConfigurableInterface && $taskConfig->getStage()) {
-                    $deployerTask->select("stage={$taskConfig->getStage()->getName()}");
-                }
-
-                if ($taskConfig instanceof ServerRoleConfigurableInterface && $taskConfig->getServerRoles()) {
-                    $roles = implode("&", $taskConfig->getServerRoles());
-                    $deployerTask->select("roles={$roles}");
-                }
+            if ($task->supports($taskConfig)) {
+                $task->configureWithTaskConfig($taskConfig);
             }
         }
     }

--- a/src/Deployer/Task/After/AfterTaskGlobal.php
+++ b/src/Deployer/Task/After/AfterTaskGlobal.php
@@ -2,10 +2,9 @@
 
 namespace Hypernode\Deploy\Deployer\Task\After;
 
-use Hypernode\Deploy\Deployer\TaskBuilder;
 use Hypernode\Deploy\Deployer\Task\TaskBase;
+use Hypernode\Deploy\Deployer\TaskBuilder;
 use Hypernode\DeployConfiguration\Configuration;
-use Hypernode\DeployConfiguration\ServerRole;
 
 use function count;
 use function Deployer\task;
@@ -32,9 +31,6 @@ class AfterTaskGlobal extends TaskBase
             };
         }
 
-        $role = ServerRole::APPLICATION;
-        task('deploy:after', $tasks)
-            ->once()
-            ->select("roles=$role");
+        task('deploy:after', $tasks)->once();
     }
 }

--- a/src/Deployer/Task/After/CachetoolTask.php
+++ b/src/Deployer/Task/After/CachetoolTask.php
@@ -3,8 +3,6 @@
 namespace Hypernode\Deploy\Deployer\Task\After;
 
 use Hypernode\Deploy\Deployer\Task\TaskBase;
-use Hypernode\DeployConfiguration\ServerRole;
-use Hypernode\Deploy\Deployer\Task\TaskInterface;
 use Hypernode\DeployConfiguration\Configuration;
 
 use function Deployer\after;
@@ -57,7 +55,7 @@ class CachetoolTask extends TaskBase
                 run('curl -L -o cachetool.phar ' . $this->getCachetoolUrl());
                 $cachetoolBinary = '{{release_path}}/cachetool.phar';
 
-                writeln(sprintf("Downloaded cachetool %s for PHP %d", $cachetoolBinary, $this->getPhpVersion()));
+                writeln(sprintf("Downloaded cachetool %s for PHP %f", $cachetoolBinary, $this->getPhpVersion()));
                 return $cachetoolBinary;
             });
             return $cachetoolBinary;
@@ -98,14 +96,11 @@ class CachetoolTask extends TaskBase
             run("cd {{release_path}} && {{bin/php}} {{bin/cachetool}} apcu:cache:clear {{cachetool_options}}");
         });
 
-
-        $role = ServerRole::APPLICATION;
-        task('cachetool:clear:opcache')
-            ->select("roles=$role");
+        task('cachetool:clear:opcache');
 
         task('cachetool:cleanup', function () {
             run('cd {{deploy_path}} && rm -f current/{{bin/cachetool}}');
-        })->select("roles=$role");
+        });
     }
 
     protected function getPhpVersion(): float
@@ -121,7 +116,7 @@ class CachetoolTask extends TaskBase
         }
 
         if ($phpVersion >= 7.3) {
-            return $this->versionBinaryMapping[6];
+            return $this->versionBinaryMapping[7];
         }
 
         if ($phpVersion >= 7.2) {

--- a/src/Deployer/Task/Deploy/CopyTask.php
+++ b/src/Deployer/Task/Deploy/CopyTask.php
@@ -4,7 +4,6 @@ namespace Hypernode\Deploy\Deployer\Task\Deploy;
 
 use Hypernode\Deploy\Deployer\Task\TaskBase;
 use Hypernode\DeployConfiguration\Configuration;
-use Hypernode\DeployConfiguration\ServerRole;
 
 use function Deployer\run;
 use function Deployer\task;
@@ -14,7 +13,6 @@ class CopyTask extends TaskBase
 {
     public function configure(Configuration $config): void
     {
-        $role = ServerRole::APPLICATION;
         task('deploy:copy:code', function () use ($config) {
             $packageFilepath = $config->getBuildArchiveFile();
             $packageFilename = pathinfo($packageFilepath, PATHINFO_BASENAME);
@@ -22,11 +20,11 @@ class CopyTask extends TaskBase
             upload($packageFilepath, '{{release_path}}');
             run('cd {{release_path}} && tar -xf ' . $packageFilename);
             run('cd {{release_path}} && rm -f ' . $packageFilename);
-        })->select("roles=$role");
+        });
 
         task('deploy:copy', [
             'deploy:copy:code',
             'deploy:shared',
-        ])->select("roles=$role");
+        ]);
     }
 }

--- a/src/Deployer/Task/Deploy/DeployTask.php
+++ b/src/Deployer/Task/Deploy/DeployTask.php
@@ -2,9 +2,8 @@
 
 namespace Hypernode\Deploy\Deployer\Task\Deploy;
 
-use Hypernode\Deploy\Deployer\Task\TaskBase;
-use Hypernode\DeployConfiguration\ServerRole;
 use Hypernode\Deploy\Deployer\RecipeLoader;
+use Hypernode\Deploy\Deployer\Task\TaskBase;
 use Hypernode\DeployConfiguration\Configuration;
 
 use function Deployer\fail;
@@ -25,13 +24,12 @@ class DeployTask extends TaskBase
     public function configure(Configuration $config): void
     {
         $this->loader->load('deploy/info.php');
-        $role = ServerRole::APPLICATION;
 
         task('deploy', [
             'deploy:upload',
             'deploy:link',
             'deploy:finalize',
-        ])->select("roles=$role");
+        ]);
 
         fail('deploy', 'deploy:failed');
     }

--- a/src/Deployer/Task/Deploy/DeployTaskGlobal.php
+++ b/src/Deployer/Task/Deploy/DeployTaskGlobal.php
@@ -4,7 +4,6 @@ namespace Hypernode\Deploy\Deployer\Task\Deploy;
 
 use Hypernode\Deploy\Deployer\Task\TaskBase;
 use Hypernode\DeployConfiguration\Configuration;
-use Hypernode\DeployConfiguration\ServerRole;
 
 use function Deployer\task;
 use function Hypernode\Deploy\Deployer\noop;
@@ -14,7 +13,6 @@ class DeployTaskGlobal extends TaskBase
     public function configure(Configuration $config): void
     {
         $tasks = $config->getDeployTasks();
-        $role = ServerRole::APPLICATION;
 
         if (count($tasks)) {
             task('deploy:deploy', $tasks);
@@ -22,6 +20,6 @@ class DeployTaskGlobal extends TaskBase
             task('deploy:deploy', noop());
         }
 
-        task('deploy:deploy', $tasks)->select("roles=$role");
+        task('deploy:deploy', $tasks);
     }
 }

--- a/src/Deployer/Task/Deploy/FinalizeTask.php
+++ b/src/Deployer/Task/Deploy/FinalizeTask.php
@@ -2,9 +2,8 @@
 
 namespace Hypernode\Deploy\Deployer\Task\Deploy;
 
-use Hypernode\Deploy\Deployer\Task\TaskBase;
-use Hypernode\DeployConfiguration\ServerRole;
 use Hypernode\Deploy\Deployer\RecipeLoader;
+use Hypernode\Deploy\Deployer\Task\TaskBase;
 use Hypernode\DeployConfiguration\Configuration;
 
 use function Deployer\after;
@@ -26,14 +25,13 @@ class FinalizeTask extends TaskBase
     public function configure(Configuration $config): void
     {
         $this->loader->load('deploy/info.php');
-        $role = ServerRole::APPLICATION;
 
         task('deploy:finalize', [
             'deploy:after',
             'deploy:unlock',
             'deploy:cleanup',
             'deploy:success',
-        ])->select("roles=$role");
+        ]);
 
         fail('deploy', 'deploy:failed');
         after('deploy:failed', 'deploy:unlock');

--- a/src/Deployer/Task/Deploy/LinkTask.php
+++ b/src/Deployer/Task/Deploy/LinkTask.php
@@ -4,7 +4,6 @@ namespace Hypernode\Deploy\Deployer\Task\Deploy;
 
 use Hypernode\Deploy\Deployer\Task\TaskBase;
 use Hypernode\DeployConfiguration\Configuration;
-use Hypernode\DeployConfiguration\ServerRole;
 
 use function Deployer\run;
 use function Deployer\task;
@@ -14,11 +13,10 @@ class LinkTask extends TaskBase
 {
     public function configure(Configuration $config): void
     {
-        $role = ServerRole::APPLICATION;
         task('deploy:link', [
             'deploy:symlink',
             'deploy:public_link',
-        ])->select("roles=$role");
+        ]);
 
         // Symlink public_html folder
         task('deploy:public_link', function () {
@@ -33,6 +31,6 @@ class LinkTask extends TaskBase
             } else {
                 run('ln -s {{current_path}}/{{public_folder}} /data/web/public');
             }
-        })->select("roles=$role");
+        });
     }
 }

--- a/src/Deployer/Task/Deploy/UploadTask.php
+++ b/src/Deployer/Task/Deploy/UploadTask.php
@@ -2,9 +2,8 @@
 
 namespace Hypernode\Deploy\Deployer\Task\Deploy;
 
-use Hypernode\Deploy\Deployer\Task\TaskBase;
-use Hypernode\DeployConfiguration\ServerRole;
 use Hypernode\Deploy\Deployer\RecipeLoader;
+use Hypernode\Deploy\Deployer\Task\TaskBase;
 use Hypernode\DeployConfiguration\Configuration;
 
 use function Deployer\fail;
@@ -25,7 +24,6 @@ class UploadTask extends TaskBase
     public function configure(Configuration $config): void
     {
         $this->loader->load('deploy/info.php');
-        $role = ServerRole::APPLICATION;
 
         task('deploy:upload', [
             'deploy:info',
@@ -33,7 +31,7 @@ class UploadTask extends TaskBase
             'deploy:prepare',
             'deploy:copy',
             'deploy:deploy',
-        ])->select("roles=$role");
+        ]);
 
         fail('deploy', 'deploy:failed');
     }


### PR DESCRIPTION
In the future, when we reiterate on Hypernode Deploy for clusters, we'll see what we really need and what's best to do. For now, it doesn't make sense to keep this in here.