### PR TITLE
Remove roles selector from builtin tasks in TaskBuilder

### DIFF
--- a/src/Deployer/TaskBuilder.php
+++ b/src/Deployer/TaskBuilder.php
@@ -8,8 +8,6 @@ use Deployer\Exception\TimeoutException;
 use Deployer\Task\Task;
 use Hypernode\DeployConfiguration\Command\Command;
 use Hypernode\DeployConfiguration\Command\DeployCommand;
-use Hypernode\DeployConfiguration\Configurable\ServerRoleConfigurableInterface;
-use Hypernode\DeployConfiguration\Configurable\StageConfigurableInterface;
 use Hypernode\DeployConfiguration\TaskConfigurationInterface;
 
 use function Deployer\parse;
@@ -53,15 +51,6 @@ class TaskBuilder
         $task = task($name, function () use ($command) {
             $this->runCommandWithin($command);
         });
-
-        if ($command instanceof StageConfigurableInterface && $command->getStage()) {
-            $task->select("stage={$command->getStage()->getName()}");
-        }
-
-        if ($command instanceof ServerRoleConfigurableInterface && $command->getServerRoles()) {
-            $roles = implode("&", $command->getServerRoles());
-            $task->select("roles=$roles");
-        }
 
         return $task;
     }


### PR DESCRIPTION
Follow-up for #79. With this, we can deprecate all the role stuff from [ByteInternet/hypernode-deploy-configuration](https://github.com/ByteInternet/hypernode-deploy-configuration/).