### PR TITLE
Allow reusing of previous brancher instance

### DIFF
--- a/ci/test/run-brancher.sh
+++ b/ci/test/run-brancher.sh
@@ -52,8 +52,14 @@ $DP test -f deployment-report.json
 $DP jq . deployment-report.json
 $DP jq .version deployment-report.json -r -e
 $DP jq .stage deployment-report.json -r -e
-$DP jq .hostnames[0] deployment-report.json -r -e
+BRANCHER_INSTANCE=$($DP jq .hostnames[0] deployment-report.json -r -e)
 $DP jq .brancher_hypernodes[0] deployment-report.json -r -e
+
+# Run another test by reusing the last instance
+$DP hypernode-deploy deploy test -f /web/deploy.php -vvv --reuse-brancher
+
+# Hostname of the reused Brancher instance should be the same as the previous one
+$DP jq .hostnames[0] deployment-report.json -r -e | grep -F "${BRANCHER_INSTANCE}"
 
 # cleanup data
 $DP hypernode-deploy cleanup -vvv

--- a/src/Brancher/BrancherHypernodeManager.php
+++ b/src/Brancher/BrancherHypernodeManager.php
@@ -57,6 +57,25 @@ class BrancherHypernodeManager
     }
 
     /**
+     * Query brancher instances for the given Hypernode and label and return the
+     * most recent Brancher instance name.
+     *
+     * @param string $hypernode The parent hypernode to query the Brancher instances from
+     * @param string[] $labels Labels to match against, may be empty
+     * @return string|null The found Brancher instance name, or null if none was found
+     */
+    public function reuseExistingBrancherHypernode(string $hypernode, array $labels = []): ?string
+    {
+        $brancherHypernodes = $this->queryBrancherHypernodes($hypernode, $labels);
+        if (count($brancherHypernodes) > 0) {
+            // Return the last brancher Hypernode, which is the most recently created one
+            return $brancherHypernodes[count($brancherHypernodes) - 1];
+        }
+
+        return null;
+    }
+
+    /**
      * Create brancher Hypernode instance for given Hypernode.
      *
      * @param string $hypernode Name of the Hypernode

--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -33,6 +33,6 @@ class Build extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        return $this->deployRunner->run($output, 'build', DeployRunner::TASK_BUILD, true, false);
+        return $this->deployRunner->run($output, 'build', DeployRunner::TASK_BUILD, true, false, false);
     }
 }

--- a/src/Command/ComposerAuth.php
+++ b/src/Command/ComposerAuth.php
@@ -34,6 +34,6 @@ class ComposerAuth extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        return $this->deployRunner->run($output, 'build', 'deploy:vendors:auth', false, false);
+        return $this->deployRunner->run($output, 'build', 'deploy:vendors:auth', false, false, false);
     }
 }

--- a/src/Command/Deploy.php
+++ b/src/Command/Deploy.php
@@ -7,6 +7,7 @@ use Hypernode\Deploy\Report\ReportWriter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 
@@ -28,6 +29,12 @@ class Deploy extends Command
         $this->setName('deploy');
         $this->setDescription('Deploy application.');
         $this->addArgument('stage', InputArgument::REQUIRED, 'Stage deploy to');
+        $this->addOption(
+            'reuse-brancher',
+            null,
+            InputOption::VALUE_NONE,
+            'Reuse the brancher Hypernode from the previous deploy. Only works when using addBrancherServer in your deploy configuration.'
+        );
     }
 
     /**
@@ -40,7 +47,8 @@ class Deploy extends Command
             $input->getArgument('stage'),
             DeployRunner::TASK_DEPLOY,
             false,
-            true
+            true,
+            $input->getOption('reuse-brancher')
         );
 
         if ($result === 0) {

--- a/src/Command/RunTask.php
+++ b/src/Command/RunTask.php
@@ -50,6 +50,7 @@ class RunTask extends Command
             $input->getArgument(self::ARGUMENT_TASK),
             $input->getOption(self::OPTION_CONFIGURE_BUILD_STAGE),
             $input->getOption(self::OPTION_CONFIGURE_SERVERS),
+            false
         );
     }
 }

--- a/src/DeployRunner.php
+++ b/src/DeployRunner.php
@@ -241,8 +241,7 @@ class DeployRunner
 
             $data = $settings;
             $data['labels'] = $labels;
-            if ($reuseBrancher && $this->brancherHypernodeManager->queryBrancherHypernodes($parentApp, $labels)) {
-                $brancherApp = $this->brancherHypernodeManager->reuseExistingBrancherHypernode($parentApp, $labels);
+            if ($reuseBrancher && $brancherApp = $this->brancherHypernodeManager->reuseExistingBrancherHypernode($parentApp, $labels)) {
                 $this->log->info(sprintf('Found existing brancher Hypernode, name is %s.', $brancherApp));
                 $server->setHostname(sprintf("%s.hypernode.io", $brancherApp));
             } else {


### PR DESCRIPTION
Useful for doing rapid development, and you don't care too much about pristine environments. Instead of creating a new Brancher node when using `addBrancherServer`, just reuse the last one if there is any.

Note the new `--reuse-brancher` flag:
```
$ hypernode-deploy deploy -h
Description:
  Deploy application.

Usage:
  deploy [options] [--] <stage>

Arguments:
  stage                 Stage deploy to

Options:
      --reuse-brancher  Reuse the brancher Hypernode from the previous deploy
  -h, --help            Display help for the given command. When no command is given display help for the list command
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -f, --file[=FILE]     Specify configuration file [default: "deploy.php"]
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```