### PR TITLE
DeployRunner: Add SIGINT handler to run fail tasks

### DIFF
--- a/src/DeployRunner.php
+++ b/src/DeployRunner.php
@@ -303,6 +303,12 @@ class DeployRunner
         $tasks = $deployer->scriptManager->getTasks($task);
         $executor = $deployer->master;
 
+        pcntl_signal(SIGINT, function () {
+            $this->log->warning("Received signal SIGINT, running fail jobs");
+            // We don't have to do anything here. Underlying processes will receive the SIGINT signal as well
+            // and that will cause the $exitCode below to be 255, which will cause the fail tasks to be run.
+        });
+
         /**
          * Set the env variable to tell deployer to deploy the hosts sequentially instead of parallel.
          * @see \Deployer\Executor\Master::runTask()


### PR DESCRIPTION
Works like this:

```
$ hypernode-deploy deploy production
task deploy:info
[production:example.hypernode.io] info deploying HEAD
task prepare:ssh
task deploy:info
[production:example.hypernode.io] info deploying HEAD
task deploy:setup
task deploy:lock
task deploy:release
task deploy:shared
task deploy:writable
task deploy:copy:code
^C[warning] Received signal SIGINT, running fail jobs
[production:example.hypernode.io]  error  in CopyTask.php on line 20:
[production:example.hypernode.io] run readlink /data/web/apps/example/release
[production:example.hypernode.io] exit code -1 (Unknown error)
task deploy:failed
task deploy:unlock
```