### PR TITLE
Discussion: Set unlimited timeout for HypernodeSettingTask

### DIFF
--- a/src/Deployer/Task/PlatformConfiguration/HypernodeSettingTask.php
+++ b/src/Deployer/Task/PlatformConfiguration/HypernodeSettingTask.php
@@ -35,7 +35,7 @@ class HypernodeSettingTask extends TaskBase implements ConfigurableTaskInterface
         $value = $config->getValue();
         $taskName = "deploy:hypernode:setting:$attribute";
         $task = task($taskName, function () use ($attribute, $value) {
-            run("hypernode-systemctl settings $attribute $value --block");
+            run("hypernode-systemctl settings $attribute $value --block", ['timeout' => null]);
         });
         after('deploy:setup', $taskName);
         return $task;


### PR DESCRIPTION
### Problem
The command 'hypernode-systemctl settings' can run for a long time on some Hypernodes/settings. This task will fail if it takes a long time.

### Solution
Let the run function know it kan take as much time as it needs by setting `['timeout' => null]`.

### Discussion
This `timeout` should probably be a configurable setting, i could think of two options:

1. a Deployer variable (hypernode_setting_task_timeout)
2. a new variable on HypernodeSettingConfiguration ($options: ['timeout'=>int|null])

There might be other way better options. Share them here.