### PR TITLE
Deployer: Pass-through GitHub Workflow commands

### DIFF
--- a/ci/test/magento/deploy1.php
+++ b/ci/test/magento/deploy1.php
@@ -2,6 +2,9 @@
 
 namespace Hypernode\DeployConfiguration;
 
+use function Deployer\run;
+use function Deployer\task;
+
 /**
  * Start by setting up the configuration
  *
@@ -9,6 +12,12 @@ namespace Hypernode\DeployConfiguration;
  * @see ApplicationTemplate\Magento2::initializeDefaultConfiguration
  */
 $configuration = new ApplicationTemplate\Magento2(['en_US', 'nl_NL']);
+
+task('debug:github:msg', static function () {
+    run('echo "::notice::This message should pass through to Github Workflow Summary!"');
+});
+
+$configuration->addDeployTask('debug:github:msg');
 
 $productionStage = $configuration->addStage('production', 'banaan1.store');
 $productionStage->addServer('hypernode', null, [], [

--- a/src/Brancher/BrancherHypernodeManager.php
+++ b/src/Brancher/BrancherHypernodeManager.php
@@ -135,11 +135,14 @@ class BrancherHypernodeManager
                 } elseif ($timeElapsed < $allowedErrorWindow) {
                     // Sometimes we get an error where the logbook is not yet available, but it will be soon.
                     // We allow a small window for this to happen, and then we throw an exception.
-                    printf(
-                        'Got an expected exception during the allowed error window of HTTP code %d, waiting for %s to become available',
-                        $e->getCode(),
-                        $brancherHypernode
+                    $this->log->info(
+                        sprintf(
+                            'Got an expected exception during the allowed error window of HTTP code %d, waiting for %s to become available.',
+                            $e->getCode(),
+                            $brancherHypernode
+                        )
                     );
+                    ;
                     continue;
                 }
             }

--- a/src/DeployerLoader.php
+++ b/src/DeployerLoader.php
@@ -6,6 +6,7 @@ namespace Hypernode\Deploy;
 
 use Deployer\Deployer;
 use Hypernode\Deploy\Console\Output\OutputWatcher;
+use Hypernode\Deploy\Printer\GithubWorkflowPrinter;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -32,6 +33,11 @@ class DeployerLoader
                 new InputOption('profile'),
             ])
         );
+        if (getenv('GITHUB_WORKFLOW')) {
+            $this->deployer['pop'] = function ($c) {
+                return new GithubWorkflowPrinter($c['output']);
+            };
+        }
 
         return $this->deployer;
     }

--- a/src/Printer/GithubWorkflowPrinter.php
+++ b/src/Printer/GithubWorkflowPrinter.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypernode\Deploy\Printer;
+
+use Deployer\Component\ProcessRunner\Printer;
+use Deployer\Host\Host;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+
+class GithubWorkflowPrinter extends Printer
+{
+    public const WORKFLOW_COMMAND_PATTERN = '/^::[a-zA-Z0-9-].*::.*$/';
+
+    private OutputInterface $output;
+
+    public function __construct(OutputInterface $output)
+    {
+        parent::__construct($output);
+        $this->output = $output;
+    }
+
+    public function contentHasWorkflowCommand(string $content): bool
+    {
+        return (bool)preg_match(self::WORKFLOW_COMMAND_PATTERN, trim($content));
+    }
+
+    public function callback(Host $host, bool $forceOutput): callable
+    {
+        return function ($type, $buffer) use ($forceOutput, $host) {
+            if (
+                $this->output->isVerbose() || $forceOutput ||
+                ($type == Process::OUT && $this->contentHasWorkflowCommand($buffer))
+            ) {
+                $this->printBuffer($type, $host, $buffer);
+            }
+        };
+    }
+
+    public function writeln(string $type, Host $host, string $line): void
+    {
+        if (empty($line)) {
+            return;
+        }
+
+        if ($type == Process::OUT && $this->contentHasWorkflowCommand($line)) {
+            $this->output->writeln($line);
+            return;
+        }
+
+        parent::writeln($type, $host, $line);
+    }
+}


### PR DESCRIPTION
If a task writes a [GitHub Workflow command](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions), it gets prefixed with the `[host]`, which renders it useless for GitHub. With this PR, it detects a GitHub Workflow command being written to the output and writes it directly (without any decorators) to the output interface.

The integration test summary should show a debug message with content:
```
This message should pass through to Github Workflow Summary!
```

Ideally we fix this in Deployer, but let's explore this idea first and see how it performs.