### PR TITLE
GithubWorkflowPrinter: Match workflow command in multiline string buffer

### DIFF
--- a/src/Printer/GithubWorkflowPrinter.php
+++ b/src/Printer/GithubWorkflowPrinter.php
@@ -11,7 +11,7 @@ use Symfony\Component\Process\Process;
 
 class GithubWorkflowPrinter extends Printer
 {
-    public const WORKFLOW_COMMAND_PATTERN = '/^::[a-zA-Z0-9-].*::.*$/';
+    public const WORKFLOW_COMMAND_PATTERN = '/^::[a-zA-Z0-9-].*::.*$/m';
 
     private OutputInterface $output;
 


### PR DESCRIPTION
Lines can come in in batches of multiple lines, so we need to match that for it to properly detect the workflow commands in the callback function