### PR TITLE
twig: Disable autoescape

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -95,7 +95,7 @@ class Bootstrap
     private function registerTwigLoader(Container $container): void
     {
         $loader = new FilesystemLoader(__DIR__ . '/Resource/template');
-        $twig = new Environment($loader);
+        $twig = new Environment($loader, ['autoescape' => false]);
         $container->set(Environment::class, $twig);
     }
 


### PR DESCRIPTION
We don't need any escaping, because the Twig template engine only supplies escaping for web-related assets.

See the `autoescape` option described here: https://twig.symfony.com/doc/2.x/api.html#environment_options