### PR TITLE
fix: resolve blocking error when switching versions

### DIFF
--- a/src/Deployer/Task/PlatformConfiguration/RedisEnableTask.php
+++ b/src/Deployer/Task/PlatformConfiguration/RedisEnableTask.php
@@ -36,7 +36,7 @@ class RedisEnableTask extends TaskBase implements ConfigurableTaskInterface
     {
         if ($config->useSupervisor()) {
             task(self::TASK_NAME, function () use ($config) {
-                run("hypernode-systemctl settings redis_version {$config->getVersion()} --block");
+                run("echo yes | hypernode-systemctl settings redis_version {$config->getVersion()} --block");
                 run("hypernode-systemctl settings supervisor_enabled True --block");
 
                 $instance = $config->getPersistence() ? 'redis-persistent' : 'redis';
@@ -44,7 +44,7 @@ class RedisEnableTask extends TaskBase implements ConfigurableTaskInterface
             });
         } else {
             task(self::TASK_NAME, function () use ($config) {
-                run("hypernode-systemctl settings redis_version {$config->getVersion()} --block");
+                run("echo yes | hypernode-systemctl settings redis_version {$config->getVersion()} --block");
                 if ($config->getPersistence()) {
                     run("hypernode-systemctl settings redis_persistent_instance --value True --block");
                 }

--- a/src/Deployer/Task/PlatformConfiguration/VarnishEnableTask.php
+++ b/src/Deployer/Task/PlatformConfiguration/VarnishEnableTask.php
@@ -36,7 +36,7 @@ class VarnishEnableTask extends TaskBase implements ConfigurableTaskInterface
     {
         if ($config->useSupervisor()) {
             task(self::TASK_NAME, function () use ($config) {
-                run("hypernode-systemctl settings varnish_version {$config->getVersion()} --block");
+                run("echo yes | hypernode-systemctl settings varnish_version {$config->getVersion()} --block");
                 run("hypernode-systemctl settings supervisor_enabled True --block");
                 run("hypernode-manage-supervisor {{domain}}.{{release_name}} --service varnish --ram {$config->getMemory()}");
             });


### PR DESCRIPTION
Resolves a blocking error during deploy when switching varnish versions

```
[production:******.hypernode.io]  error  in VarnishEnableTask.php on line 39:
[production:******.hypernode.io] run hypernode-systemctl settings varnish_version 6.0 --block
[production:******.hypernode.io] err Traceback (most recent call last):
[production:******.hypernode.io] err File "/usr/bin/hypernode-systemctl", line 11, in <module>
[production:******.hypernode.io] err load_entry_point('kamikaze3==20240215.10[140](*****)5', 'console_scripts', 'hypernode-systemctl')()
[production:******.hypernode.io] err File "/usr/lib/python3/dist-packages/kamikaze3/systemctl/main.py", line 132, in main
[production:******.hypernode.io] err args = parse_arguments(args=args)
[production:******.hypernode.io] err File "/usr/lib/python3/dist-packages/kamikaze3/systemctl/parsing.py", line 144, in parse_arguments
[production:******.hypernode.io] err request_confirmation(validation_string)
[production:******.hypernode.io] err File "/usr/lib/python3/dist-packages/kamikaze3/utils.py", line 54, in request_confirmation
[production:******.hypernode.io] err response = input(prompt).lower()
[production:******.hypernode.io] err EOFError: EOF when reading a line
[production:******.hypernode.io] WARNING: When you change Varnish version the default passthrough VCL will be set. Make sure you copy your /data/var/varnish/default.vcl somewhere safe first!
[production:******.hypernode.io] Continue? (yes/no)
[production:******.hypernode.io] exit code 1 (General error)

```