### PR TITLE
fix: no longer automatically execute cachetool task

### DIFF
--- a/src/Deployer/Task/After/CachetoolTask.php
+++ b/src/Deployer/Task/After/CachetoolTask.php
@@ -35,8 +35,6 @@ class CachetoolTask extends TaskBase
 
     public function register(): void
     {
-        after('deploy:symlink', 'cachetool:clear:opcache');
-        after('cachetool:clear:opcache', 'cachetool:cleanup');
     }
 
     public function configure(Configuration $config): void


### PR DESCRIPTION
## Issue
Currently the Hypernode deploy always executes the cachetool opcache flush task. 
This task is extremely flakey and fails a lot on our end. Same issue as on the Hipex servers.

## Solution

This task can be safely removed, or at least marked optional as it's not required on Hypernode.

For reference see: https://deployer.org/docs/7.x/avoid-php-fpm-reloading
And in the Hypernode NGINX configuration `/etc/nginx/fastcgi_params` the following line `fastcgi_param   SCRIPT_FILENAME     $realpath_root$fastcgi_script_name;` 
Which makes it so that no longer opcache has to be flushed.

I've tested this and validated this on multiple customers on our end.
