### PR TITLE
ci: Add Node.js 20 to build matrix

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,12 +18,13 @@ jobs:
           - 14
           - 16
           - 18
+          - 20
     runs-on: ubuntu-latest
     env:
       PHP_VERSION: ${{ matrix.php_version }}
       NODE_VERSION: ${{ matrix.node_version }}
       LATEST_PHP_VERSION: 8.3
-      LATEST_NODE_VERSION: 18
+      LATEST_NODE_VERSION: 20
     steps:
       - name: Checkout hypernode-deploy
         uses: actions/checkout@v3


### PR DESCRIPTION
This will make Node.js 20 for all supported PHP versions available