### PR TITLE
ci: Run test workflow on base repository

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,6 @@
 name: Run tests for PR
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   integration_test:


### PR DESCRIPTION
By running the test workflow on the base repository, a contributor can make use of our integration tests etc.