### PR TITLE
Fix regressions

### DIFF
--- a/src/DeployRunner.php
+++ b/src/DeployRunner.php
@@ -150,20 +150,11 @@ class DeployRunner
             if ($task->supports($taskConfig)) {
                 $task = $task->configureWithTaskConfig($taskConfig);
 
-                if ($task && $taskConfig instanceof ServerRoleConfigurableInterface) {
-                    $this->configureTaskOnServerRoles($task, $taskConfig);
-                }
-
                 if ($task && $taskConfig instanceof StageConfigurableInterface) {
                     $this->configureTaskOnStage($task, $taskConfig);
                 }
             }
         }
-    }
-
-    private function configureTaskOnServerRoles(Task $task, ServerRoleConfigurableInterface $taskConfiguration)
-    {
-        $task->select('role=' . implode(',role=', $taskConfiguration->getServerRoles()));
     }
 
     private function configureTaskOnStage(Task $task, StageConfigurableInterface $taskConfiguration)

--- a/src/DeployRunner.php
+++ b/src/DeployRunner.php
@@ -148,10 +148,10 @@ class DeployRunner
 
         foreach ($configurations as $taskConfig) {
             if ($task->supports($taskConfig)) {
-                $task = $task->configureWithTaskConfig($taskConfig);
+                $deployerTask = $task->configureWithTaskConfig($taskConfig);
 
-                if ($task && $taskConfig instanceof StageConfigurableInterface) {
-                    $this->configureTaskOnStage($task, $taskConfig);
+                if ($deployerTask && $taskConfig instanceof StageConfigurableInterface) {
+                    $this->configureTaskOnStage($deployerTask, $taskConfig);
                 }
             }
         }


### PR DESCRIPTION
The master branch contains a few regressions:
- Accidental variable type mixing (https://github.com/ByteInternet/hypernode-deploy/pull/113/commits/3cad9f278abff473a4e8bd8807d73e9c116c67cf)
  `PHP Fatal error:  Uncaught Error: Call to undefined method Deployer\Task\Task::supports() in phar:///bin/hypernode-deploy/src/DeployRunner.php:150`
- Role selection does not work as intended, causing certain tasks to be skipped (https://github.com/ByteInternet/hypernode-deploy/pull/113/commits/c4000f681474aad8490cbc603b4f46a221335ced)