### PR TITLE
ci: Checkout pull request ref instead

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout hypernode-deploy
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
       - name: Run general testsuite
         if: ${{ matrix.testsuite == 'general' }}
         run: MAGENTO_REPO=./magento2 ./runtests.sh general


### PR DESCRIPTION
Commit 17806306 set the pull request event to `pull_request_target`, which means the pipelines run on the base ref with the secrets from base as well. That's all fine, but we actually want to test the code on the pull request ref