### PR TITLE
Revert "ci: Run test workflow on base repository"

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,6 @@
 name: Run tests for PR
 on:
-  pull_request_target:
+  pull_request:
 
 jobs:
   integration_test:


### PR DESCRIPTION
Reverts ByteInternet/hypernode-deploy#111

Not working as expected, just builds master instead of the pull_request_target event revision