### PR TITLE
Add safe directory wildcard to dockerfiles

### DIFF
--- a/ci/build/Dockerfile
+++ b/ci/build/Dockerfile
@@ -128,6 +128,9 @@ RUN rm -rvf \
         /var/lib/apt/lists/* \
     && apt-get autoremove -y
 
+# Allow hypernode-deploy to be ran in ordinary git repository locations
+RUN git config --global --add safe.directory "*"
+
 # Setup default command
 CMD ["hypernode-deploy"]
 


### PR DESCRIPTION
Fixes `fatal: detected dubious ownership in repository at ...` issues some users experience when using Hypernode Deploy