### PR TITLE
fix: no cli input for deploy:hypernode:setting elasticsearch_enabled …

### DIFF
--- a/src/Deployer/Task/PlatformConfiguration/HypernodeSettingTask.php
+++ b/src/Deployer/Task/PlatformConfiguration/HypernodeSettingTask.php
@@ -35,7 +35,7 @@ class HypernodeSettingTask extends TaskBase implements ConfigurableTaskInterface
         $value = $config->getValue();
         $taskName = "deploy:hypernode:setting:$attribute";
         $task = task($taskName, function () use ($attribute, $value) {
-            run("hypernode-systemctl settings $attribute $value --block");
+            run("yes | hypernode-systemctl settings $attribute $value --block");
         });
         after('deploy:setup', $taskName);
         return $task;


### PR DESCRIPTION
fix no cli input for `deploy:hypernode:setting elasticsearch_enabled True --block`

Expected:
```
deploy:hypernode:setting elasticsearch_enabled True --block
WARNING: Enabling ElasticSearch will disable OpenSearch, which you are currently running.
Operation was successful.
```

Actual result:
```
hypernode-systemctl settings elasticsearch_enabled True --block
WARNING: Enabling ElasticSearch will disable OpenSearch, which you are currently running.
Continue? (yes/no)
````