### PR TITLE
Add 'tree' command to Hypernode Deploy to get overview and list of tasks for a stage

### DIFF
--- a/src/Command/Tree.php
+++ b/src/Command/Tree.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Hypernode\Deploy\Command;
+
+use Deployer\Deployer;
+use Deployer\Command\TreeCommand;
+use Symfony\Component\Console\Input\InputInterface as Input;
+use Symfony\Component\Console\Output\OutputInterface as Output;
+use Hypernode\Deploy\DeployRunner;
+use Hypernode\Deploy\Exception\InvalidConfigurationException;
+use Hypernode\Deploy\Exception\ValidationException;
+
+class Tree extends TreeCommand
+{
+    /**
+     * @var DeployRunner
+     */
+    private $deployRunner;
+
+    public function __construct(
+        Deployer $deployer,
+        DeployRunner $deployRunner,
+    ) {
+        parent::__construct($deployer);
+        $this->deployRunner = $deployRunner;
+    }
+
+    protected function execute(Input $input, Output $output): int
+    {
+        try {
+            $this->deployRunner->prepare(true, true, $input->getArgument('task'), false);
+        } catch (InvalidConfigurationException | ValidationException $e) {
+            $output->write($e->getMessage());
+            return 1;
+        }
+        $result = parent::execute($input, $output);
+
+        return $result;
+    }
+}

--- a/src/Command/Tree.php
+++ b/src/Command/Tree.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-
 namespace Hypernode\Deploy\Command;
 
 use Deployer\Deployer;

--- a/src/Command/Tree.php
+++ b/src/Command/Tree.php
@@ -1,5 +1,8 @@
 <?php
 
+declare(strict_types=1);
+
+
 namespace Hypernode\Deploy\Command;
 
 use Deployer\Deployer;

--- a/src/DeployRunner.php
+++ b/src/DeployRunner.php
@@ -104,7 +104,7 @@ class DeployRunner
      * @throws InvalidConfigurationException
      * @throws Throwable
      */
-    private function prepare(
+    public function prepare(
         bool $configureBuildStage,
         bool $configureServers,
         string $stage,


### PR DESCRIPTION
Example output:

```
» hypernode-deploy tree deploy     
The task-tree for deploy:
├── slack:notify  // before deploy
└── deploy
    ├── deploy:upload
    │   ├── prepare:ssh
    │   ├── deploy:info
    │   ├── deploy:prepare
    │   │   ├── deploy:info
    │   │   ├── deploy:setup
    │   │   ├── deploy:lock
    │   │   ├── deploy:release
    │   │   ├── deploy:shared
    │   │   └── deploy:writable
    │   ├── deploy:copy
    │   │   ├── deploy:copy:code
    │   │   └── deploy:shared
    │   └── deploy:deploy
    ├── deploy:link
    │   ├── deploy:symlink
    │   ├── cachetool:clear:opcache  // after deploy:symlink
    │   ├── cachetool:cleanup  // after cachetool:clear:opcache
    │   └── deploy:public_link
    └── deploy:finalize
        ├── deploy:after
        ├── deploy:unlock
        ├── deploy:cleanup
        └── deploy:success
        └── slack:notify:success  // after deploy:success
```