### PR TITLE
Use debian-slim image for building hypernode deploy

### DIFF
--- a/ci/build/Dockerfile
+++ b/ci/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM debian:bookworm-slim
 
 ARG NODE_VERSION
 ARG PHP_VERSION


### PR DESCRIPTION
```
hypernode_deploy_dev        php8.4-node24     1.15GB
hypernode_deploy_dev-slim   php8.4-node24     974MB
```

That's a free ~17% improvement
