### PR TITLE
Add high-performance static content deployment task

### DIFF
--- a/ci/build/Dockerfile
+++ b/ci/build/Dockerfile
@@ -117,6 +117,11 @@ RUN curl -sS https://getcomposer.org/installer | php -- --2.2 --filename=compose
 # Use version 1 for main composer binary
 RUN rm -f /usr/local/bin/composer; ln -s /usr/local/bin/composer2 /usr/local/bin/composer
 
+# Install elgentos magento2-static-deploy binary for high-performance static content deployment
+RUN curl -sL -o /opt/magento2-static-deploy \
+    https://github.com/elgentos/magento2-static-deploy/releases/latest/download/magento2-static-deploy-linux-amd64 \
+    && chmod +x /opt/magento2-static-deploy
+
 # Set python3 as default python executable
 RUN ln -s /usr/bin/python3 /usr/local/bin/python
 

--- a/src/Deployer/Task/Build/HighPerformanceStaticDeployTask.php
+++ b/src/Deployer/Task/Build/HighPerformanceStaticDeployTask.php
@@ -19,9 +19,7 @@ use function Deployer\within;
  */
 class HighPerformanceStaticDeployTask extends TaskBase
 {
-    private const BINARY_URL_VERSIONED = 'https://github.com/elgentos/magento2-static-deploy/releases/download/%s/magento2-static-deploy-linux-amd64';
-    private const BINARY_URL_LATEST = 'https://github.com/elgentos/magento2-static-deploy/releases/latest/download/magento2-static-deploy-linux-amd64';
-    private const DEFAULT_VERSION = 'latest';
+    private const BINARY_PATH = '/opt/magento2-static-deploy';
 
     public function configure(Configuration $config): void
     {
@@ -29,21 +27,14 @@ class HighPerformanceStaticDeployTask extends TaskBase
             return;
         }
 
-        $version = $this->getVersion($config);
-
-        task('magento:deploy:assets', function () use ($version) {
-            within('{{release_or_current_path}}', function () use ($version) {
-                run(sprintf('curl -sL -o /tmp/magento2-static-deploy %s', $this->getBinaryUrl($version)));
-                run('chmod +x /tmp/magento2-static-deploy');
-            });
-
+        task('magento:deploy:assets', function () {
             $themes = get('magento_themes', []);
             $themeArgs = $this->buildThemeArgs($themes);
             $locales = get('static_content_locales', 'en_US');
             $contentVersion = get('content_version', time());
 
             within('{{release_or_current_path}}', function () use ($themeArgs, $locales, $contentVersion) {
-                run("/tmp/magento2-static-deploy --force --area=frontend --area=adminhtml $themeArgs --content-version=$contentVersion --verbose $locales");
+                run(self::BINARY_PATH . " --force --area=frontend --area=adminhtml $themeArgs --content-version=$contentVersion --verbose $locales");
             });
         })->select('stage=build');
     }
@@ -56,25 +47,6 @@ class HighPerformanceStaticDeployTask extends TaskBase
         return $variables['high_performance_static_deploy']
             ?? $buildVariables['high_performance_static_deploy']
             ?? false;
-    }
-
-    public function getVersion(Configuration $config): string
-    {
-        $variables = $config->getVariables();
-        $buildVariables = $config->getVariables('build');
-
-        return $variables['high_performance_static_deploy_version']
-            ?? $buildVariables['high_performance_static_deploy_version']
-            ?? self::DEFAULT_VERSION;
-    }
-
-    public function getBinaryUrl(string $version): string
-    {
-        if ($version === 'latest') {
-            return self::BINARY_URL_LATEST;
-        }
-
-        return sprintf(self::BINARY_URL_VERSIONED, $version);
     }
 
     /**

--- a/src/Deployer/Task/Build/HighPerformanceStaticDeployTask.php
+++ b/src/Deployer/Task/Build/HighPerformanceStaticDeployTask.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypernode\Deploy\Deployer\Task\Build;
+
+use Hypernode\Deploy\Deployer\Task\TaskBase;
+use Hypernode\DeployConfiguration\Configuration;
+
+use function Deployer\get;
+use function Deployer\run;
+use function Deployer\task;
+use function Deployer\within;
+
+/**
+ * High-performance static content deployment using elgentos/magento2-static-deploy.
+ *
+ * @see https://github.com/elgentos/magento2-static-deploy
+ */
+class HighPerformanceStaticDeployTask extends TaskBase
+{
+    private const BINARY_URL_VERSIONED = 'https://github.com/elgentos/magento2-static-deploy/releases/download/%s/magento2-static-deploy-linux-amd64';
+    private const BINARY_URL_LATEST = 'https://github.com/elgentos/magento2-static-deploy/releases/latest/download/magento2-static-deploy-linux-amd64';
+    private const DEFAULT_VERSION = 'latest';
+
+    public function configure(Configuration $config): void
+    {
+        if (!$this->isEnabled($config)) {
+            return;
+        }
+
+        $version = $this->getVersion($config);
+
+        task('magento:deploy:assets', function () use ($version) {
+            within('{{release_or_current_path}}', function () use ($version) {
+                run(sprintf('curl -sL -o /tmp/magento2-static-deploy %s', $this->getBinaryUrl($version)));
+                run('chmod +x /tmp/magento2-static-deploy');
+            });
+
+            $themes = get('magento_themes', []);
+            $themeArgs = $this->buildThemeArgs($themes);
+            $locales = get('static_content_locales', 'en_US');
+            $contentVersion = get('content_version', time());
+
+            within('{{release_or_current_path}}', function () use ($themeArgs, $locales, $contentVersion) {
+                run("/tmp/magento2-static-deploy --force --area=frontend --area=adminhtml $themeArgs --content-version=$contentVersion --verbose $locales");
+            });
+        })->select('stage=build');
+    }
+
+    public function isEnabled(Configuration $config): bool
+    {
+        $variables = $config->getVariables();
+        $buildVariables = $config->getVariables('build');
+
+        return $variables['high_performance_static_deploy']
+            ?? $buildVariables['high_performance_static_deploy']
+            ?? false;
+    }
+
+    public function getVersion(Configuration $config): string
+    {
+        $variables = $config->getVariables();
+        $buildVariables = $config->getVariables('build');
+
+        return $variables['high_performance_static_deploy_version']
+            ?? $buildVariables['high_performance_static_deploy_version']
+            ?? self::DEFAULT_VERSION;
+    }
+
+    public function getBinaryUrl(string $version): string
+    {
+        if ($version === 'latest') {
+            return self::BINARY_URL_LATEST;
+        }
+
+        return sprintf(self::BINARY_URL_VERSIONED, $version);
+    }
+
+    /**
+     * @param array<string, string> $themes
+     */
+    public function buildThemeArgs(array $themes): string
+    {
+        return implode(' ', array_map(fn($t) => "--theme=$t", array_keys($themes)));
+    }
+}

--- a/tests/Unit/Deployer/Task/Build/HighPerformanceStaticDeployTaskTest.php
+++ b/tests/Unit/Deployer/Task/Build/HighPerformanceStaticDeployTaskTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hypernode\Deploy\Tests\Unit\Deployer\Task\Build;
+
+use Hypernode\Deploy\Deployer\Task\Build\HighPerformanceStaticDeployTask;
+use Hypernode\DeployConfiguration\Configuration;
+use PHPUnit\Framework\TestCase;
+
+class HighPerformanceStaticDeployTaskTest extends TestCase
+{
+    private HighPerformanceStaticDeployTask $task;
+
+    protected function setUp(): void
+    {
+        $this->task = new HighPerformanceStaticDeployTask();
+    }
+
+    public function testIsEnabledReturnsFalseWhenNotConfigured(): void
+    {
+        $config = $this->createMock(Configuration::class);
+        $config->method('getVariables')->willReturn([]);
+
+        $this->assertFalse($this->task->isEnabled($config));
+    }
+
+    public function testIsEnabledReturnsTrueWhenEnabledInVariables(): void
+    {
+        $config = $this->createMock(Configuration::class);
+        $config->method('getVariables')
+            ->willReturnCallback(fn(string $stage = 'all') => match ($stage) {
+                'all' => ['high_performance_static_deploy' => true],
+                default => [],
+            });
+
+        $this->assertTrue($this->task->isEnabled($config));
+    }
+
+    public function testIsEnabledReturnsTrueWhenEnabledInBuildVariables(): void
+    {
+        $config = $this->createMock(Configuration::class);
+        $config->method('getVariables')
+            ->willReturnCallback(fn(string $stage = 'all') => match ($stage) {
+                'build' => ['high_performance_static_deploy' => true],
+                default => [],
+            });
+
+        $this->assertTrue($this->task->isEnabled($config));
+    }
+
+    public function testIsEnabledReturnsFalseWhenExplicitlyDisabled(): void
+    {
+        $config = $this->createMock(Configuration::class);
+        $config->method('getVariables')
+            ->willReturnCallback(fn(string $stage = 'all') => match ($stage) {
+                'all' => ['high_performance_static_deploy' => false],
+                default => [],
+            });
+
+        $this->assertFalse($this->task->isEnabled($config));
+    }
+
+    public function testGetVersionReturnsDefaultWhenNotConfigured(): void
+    {
+        $config = $this->createMock(Configuration::class);
+        $config->method('getVariables')->willReturn([]);
+
+        $this->assertSame('latest', $this->task->getVersion($config));
+    }
+
+    public function testGetVersionReturnsConfiguredVersion(): void
+    {
+        $config = $this->createMock(Configuration::class);
+        $config->method('getVariables')
+            ->willReturnCallback(fn(string $stage = 'all') => match ($stage) {
+                'all' => ['high_performance_static_deploy_version' => '1.0.0'],
+                default => [],
+            });
+
+        $this->assertSame('1.0.0', $this->task->getVersion($config));
+    }
+
+    public function testGetVersionReturnsBuildVersionWhenNotInAllVariables(): void
+    {
+        $config = $this->createMock(Configuration::class);
+        $config->method('getVariables')
+            ->willReturnCallback(fn(string $stage = 'all') => match ($stage) {
+                'build' => ['high_performance_static_deploy_version' => '2.0.0'],
+                default => [],
+            });
+
+        $this->assertSame('2.0.0', $this->task->getVersion($config));
+    }
+
+    public function testGetBinaryUrlReturnsLatestUrl(): void
+    {
+        $result = $this->task->getBinaryUrl('latest');
+
+        $this->assertSame(
+            'https://github.com/elgentos/magento2-static-deploy/releases/latest/download/magento2-static-deploy-linux-amd64',
+            $result
+        );
+    }
+
+    public function testGetBinaryUrlReturnsVersionedUrl(): void
+    {
+        $result = $this->task->getBinaryUrl('0.0.8');
+
+        $this->assertSame(
+            'https://github.com/elgentos/magento2-static-deploy/releases/download/0.0.8/magento2-static-deploy-linux-amd64',
+            $result
+        );
+    }
+
+    public function testGetBinaryUrlWithDifferentVersion(): void
+    {
+        $result = $this->task->getBinaryUrl('1.2.3');
+
+        $this->assertStringContainsString('1.2.3', $result);
+        $this->assertStringContainsString('magento2-static-deploy-linux-amd64', $result);
+    }
+
+    public function testBuildThemeArgsWithSingleTheme(): void
+    {
+        $themes = ['Vendor/theme' => 'nl_NL en_US'];
+
+        $result = $this->task->buildThemeArgs($themes);
+
+        $this->assertSame('--theme=Vendor/theme', $result);
+    }
+
+    public function testBuildThemeArgsWithMultipleThemes(): void
+    {
+        $themes = [
+            'Vendor/theme1' => 'nl_NL',
+            'Vendor/theme2' => 'en_US',
+            'Vendor/theme3' => 'de_DE',
+        ];
+
+        $result = $this->task->buildThemeArgs($themes);
+
+        $this->assertSame('--theme=Vendor/theme1 --theme=Vendor/theme2 --theme=Vendor/theme3', $result);
+    }
+
+    public function testBuildThemeArgsWithEmptyArray(): void
+    {
+        $result = $this->task->buildThemeArgs([]);
+
+        $this->assertSame('', $result);
+    }
+}

--- a/tests/Unit/Deployer/Task/Build/HighPerformanceStaticDeployTaskTest.php
+++ b/tests/Unit/Deployer/Task/Build/HighPerformanceStaticDeployTaskTest.php
@@ -61,66 +61,6 @@ class HighPerformanceStaticDeployTaskTest extends TestCase
         $this->assertFalse($this->task->isEnabled($config));
     }
 
-    public function testGetVersionReturnsDefaultWhenNotConfigured(): void
-    {
-        $config = $this->createMock(Configuration::class);
-        $config->method('getVariables')->willReturn([]);
-
-        $this->assertSame('latest', $this->task->getVersion($config));
-    }
-
-    public function testGetVersionReturnsConfiguredVersion(): void
-    {
-        $config = $this->createMock(Configuration::class);
-        $config->method('getVariables')
-            ->willReturnCallback(fn(string $stage = 'all') => match ($stage) {
-                'all' => ['high_performance_static_deploy_version' => '1.0.0'],
-                default => [],
-            });
-
-        $this->assertSame('1.0.0', $this->task->getVersion($config));
-    }
-
-    public function testGetVersionReturnsBuildVersionWhenNotInAllVariables(): void
-    {
-        $config = $this->createMock(Configuration::class);
-        $config->method('getVariables')
-            ->willReturnCallback(fn(string $stage = 'all') => match ($stage) {
-                'build' => ['high_performance_static_deploy_version' => '2.0.0'],
-                default => [],
-            });
-
-        $this->assertSame('2.0.0', $this->task->getVersion($config));
-    }
-
-    public function testGetBinaryUrlReturnsLatestUrl(): void
-    {
-        $result = $this->task->getBinaryUrl('latest');
-
-        $this->assertSame(
-            'https://github.com/elgentos/magento2-static-deploy/releases/latest/download/magento2-static-deploy-linux-amd64',
-            $result
-        );
-    }
-
-    public function testGetBinaryUrlReturnsVersionedUrl(): void
-    {
-        $result = $this->task->getBinaryUrl('0.0.8');
-
-        $this->assertSame(
-            'https://github.com/elgentos/magento2-static-deploy/releases/download/0.0.8/magento2-static-deploy-linux-amd64',
-            $result
-        );
-    }
-
-    public function testGetBinaryUrlWithDifferentVersion(): void
-    {
-        $result = $this->task->getBinaryUrl('1.2.3');
-
-        $this->assertStringContainsString('1.2.3', $result);
-        $this->assertStringContainsString('magento2-static-deploy-linux-amd64', $result);
-    }
-
     public function testBuildThemeArgsWithSingleTheme(): void
     {
         $themes = ['Vendor/theme' => 'nl_NL en_US'];


### PR DESCRIPTION
Integrate elgentos/magento2-static-deploy Go binary for 230-380x faster static content deployment. The task overrides magento:deploy:assets when enabled via enableHighPerformanceStaticDeploy() in the configuration.

Features:
- Downloads Go binary from GitHub releases (supports 'latest' or specific version)
- Deploys both frontend and adminhtml areas
- Uses Deployer variables: magento_themes, static_content_locales, content_version
- Auto-detects Hyvä vs Luma themes (Luma dispatched to bin/magento)