### PR TITLE
Catch HypernodeApiServerException in brancher polling

### DIFF
--- a/src/Brancher/BrancherHypernodeManager.php
+++ b/src/Brancher/BrancherHypernodeManager.php
@@ -205,7 +205,7 @@ class BrancherHypernodeManager
             } catch (HypernodeApiClientException | HypernodeApiServerException $e) {
                 // A 404 not found means there are no flows in the logbook yet, we should wait.
                 // Otherwise, there's an error, and it should be propagated.
-                if ($e->getCode() !== 404) {
+                if (!in_array($e->getCode(), [404, 502])) {
                     throw $e;
                 } elseif (($timeElapsed - $logbookStartTime) < $allowedErrorWindow) {
                     // Sometimes we get an error where the logbook is not yet available, but it will be soon.

--- a/src/Brancher/BrancherHypernodeManager.php
+++ b/src/Brancher/BrancherHypernodeManager.php
@@ -202,7 +202,7 @@ class BrancherHypernodeManager
                     $resolved = true;
                     break;
                 }
-            } catch (HypernodeApiClientException $e) {
+            } catch (HypernodeApiClientException | HypernodeApiServerException $e) {
                 // A 404 not found means there are no flows in the logbook yet, we should wait.
                 // Otherwise, there's an error, and it should be propagated.
                 if ($e->getCode() !== 404) {

--- a/src/DeployRunner.php
+++ b/src/DeployRunner.php
@@ -7,6 +7,7 @@ use Deployer\Exception\Exception;
 use Deployer\Exception\GracefulShutdownException;
 use Deployer\Host\Host;
 use Deployer\Task\Task;
+use Hypernode\Api\Exception\HypernodeApiServerException;
 use Hypernode\Deploy\Brancher\BrancherHypernodeManager;
 use Hypernode\Deploy\Deployer\RecipeLoader;
 use Hypernode\Deploy\Deployer\Task\ConfigurableTaskInterface;
@@ -313,7 +314,7 @@ class DeployRunner
                     $reachabilityCheckInterval
                 );
                 $this->log->info('Brancher Hypernode has become available!');
-            } catch (CreateBrancherHypernodeFailedException | TimeoutException $e) {
+            } catch (CreateBrancherHypernodeFailedException | TimeoutException | HypernodeApiServerException $e) {
                 if (in_array($brancherApp, $this->brancherHypernodesRegistered)) {
                     $this->brancherHypernodeManager->cancel($brancherApp);
                 }

--- a/tests/Unit/Brancher/BrancherHypernodeManagerTest.php
+++ b/tests/Unit/Brancher/BrancherHypernodeManagerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hypernode\Deploy\Tests\Unit\Brancher;
 
 use Hypernode\Api\Exception\HypernodeApiClientException;
+use Hypernode\Api\Exception\HypernodeApiServerException;
 use Hypernode\Api\HypernodeClient;
 use Hypernode\Api\Resource\Logbook\Flow;
 use Hypernode\Api\Service\BrancherApp;
@@ -161,6 +162,25 @@ class BrancherHypernodeManagerTest extends TestCase
             ->willThrowException($exception500);
 
         $this->expectException(HypernodeApiClientException::class);
+
+        $this->manager->waitForAvailability('test-brancher', 1500, 6, 10);
+    }
+
+    public function testLogbookServerErrorPropagates(): void
+    {
+        $this->sshPoller->pollResults = array_fill(0, 5, false);
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(503);
+        $response->method('getBody')->willReturn('Service Unavailable');
+        $exception503 = new HypernodeApiServerException($response);
+
+        $this->logbook->expects($this->once())
+            ->method('getList')
+            ->with('test-brancher')
+            ->willThrowException($exception503);
+
+        $this->expectException(HypernodeApiServerException::class);
 
         $this->manager->waitForAvailability('test-brancher', 1500, 6, 10);
     }


### PR DESCRIPTION
The logbook polling loop in `BrancherHypernodeManager` only caught `HypernodeApiClientException` (4xx), meaning 5xx server errors from the API would bubble up as uncaught exceptions and kill the deploy. this widens the catch to also handle `HypernodeApiServerException`, same for `DeployRunner`'s brancher provisioning block