### PR TITLE
Only execute AfterTasks that are Commands in the Commands-flow

### DIFF
--- a/src/Deployer/Task/After/AfterTaskGlobal.php
+++ b/src/Deployer/Task/After/AfterTaskGlobal.php
@@ -4,7 +4,9 @@ namespace Hypernode\Deploy\Deployer\Task\After;
 
 use Hypernode\Deploy\Deployer\Task\TaskBase;
 use Hypernode\Deploy\Deployer\TaskBuilder;
+use Hypernode\DeployConfiguration\Command\Command;
 use Hypernode\DeployConfiguration\Configuration;
+use Hypernode\DeployConfiguration\TaskConfigurationInterface;
 
 use function count;
 use function Deployer\task;
@@ -24,7 +26,12 @@ class AfterTaskGlobal extends TaskBase
 
     public function configure(Configuration $config): void
     {
-        $tasks = $this->taskBuilder->buildAll($config->getAfterDeployTasks(), 'deploy:after');
+        $commands = array_values(array_filter(
+            $config->getAfterDeployTasks(),
+            fn (TaskConfigurationInterface $task): bool => $task instanceof Command
+        ));
+
+        $tasks = $this->taskBuilder->buildAll($commands, 'deploy:after');
         if (count($tasks) === 0) {
             $tasks = function (): void {
                 writeln('No after deploy tasks defined');

--- a/src/Deployer/TaskBuilder.php
+++ b/src/Deployer/TaskBuilder.php
@@ -19,7 +19,7 @@ use function Deployer\writeln;
 class TaskBuilder
 {
     /**
-     * @param TaskConfigurationInterface[] $commands
+     * @param Command[] $commands
      *
      * @param string $namePrefix
      * @return string[]
@@ -32,7 +32,6 @@ class TaskBuilder
         foreach ($commands as $command) {
             $name = $namePrefix . ':' . \count($tasks);
 
-            /** @var Command $command */
             $this->build($command, $name);
 
             $tasks[] = $name;


### PR DESCRIPTION
Fixes a bug where AfterTask's are being interpreted as the PlatformConfiguration-path (which is correct), but also as a Command. On the latter route, we check explicitly if the task is a Command, and execute those.